### PR TITLE
feat(skill): add sre skills

### DIFF
--- a/.config/claude/skills/sre-analyze-alert/SKILL.md
+++ b/.config/claude/skills/sre-analyze-alert/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: sre-analyze-alert
+description: |
+  Analyze an SRE alert (typically from Grafana Alertmanager) end-to-end: explain
+  why it is firing, correlate evidence from metrics, logs, traces, profiles and
+  the Kubernetes cluster, identify the most likely root cause, and propose a
+  concrete fix. Triggers when the user pastes an alert payload, an alert URL, or
+  asks to "investigate", "analyze", "debug", or "find the root cause" of an
+  alert. Delegates data collection to the `sre-grafana` and `sre-kubernetes`
+  skills.
+---
+
+# SRE: Analyze Alert
+
+You are acting as an SRE on-call engineer. The user has handed you an alert and
+expects a structured investigation that ends with a root cause and a fix.
+
+## Inputs You Should Expect
+
+Alerts are usually pasted as a markdown block from Grafana Alertmanager. Parse
+out at least the following fields before you start investigating:
+
+| Field                     | Where to find it                  | Used for                                          |
+| ------------------------- | --------------------------------- | ------------------------------------------------- |
+| `alertname`               | Title and `Labels`                | Naming the incident, finding runbook              |
+| `Grafana URL`             | Top of payload                    | Base URL for all Grafana API calls                |
+| `Grafana Credentials`     | Top of payload (`Bearer <token>`) | Authentication header                             |
+| `Started` timestamp       | Top of payload                    | Anchors the time window for queries               |
+| `Summary` / `Description` | Body                              | First-pass hypothesis, often contains the runbook |
+| `runbook_url`             | `Annotations`                     | Pre-existing playbook — always check it first     |
+
+If any of these are missing, ask the user before guessing.
+
+> **Note:** If the user only provides an alert url in the format
+> `<grafana-url>/alerting/<grafana-alertmanager-datasource>/<alert-id>/view`
+> (e.g.,
+> `https://grafana.example.com/alerting/grafana/alert-kubenodeeviction/view`),
+> use [`references/grafana-alert-source.md`](references/grafana-alert-source.md)
+> to get the alert details before starting the investigation.
+
+## Workflow
+
+Do these phases **in order**. Do not skip phases — even when a hypothesis seems
+obvious, confirm it with data before claiming a root cause.
+
+### 1. Read the Alert Carefully
+
+- Restate the alert in one sentence so the user can confirm you understood it.
+- Extract the time window: queries should span roughly `Started - 30m` to `now`
+  (widen if the alert has been firing for hours).
+- Open the runbook URL if present and follow its check-list — those checks are
+  authored by the team that owns the alert and usually point at the real cause.
+
+### 2. Form a Hypothesis
+
+State 1–3 candidate causes before pulling data. This keeps the investigation
+focused and prevents you from drowning in metrics. Example for a
+`PostgresTransactionTimeout`:
+
+1. A long-running migration or bulk job is holding a transaction open.
+2. A specific service is leaking transactions (missing commit/rollback).
+3. `transaction_timeout` was recently lowered and now trips on normal workload.
+
+### 3. Collect Evidence via `sre-grafana`
+
+Use the `sre-grafana` skill to query for, at minimum:
+
+- **Metrics** that match the alert expression and any obvious correlates
+  (saturation, error rate, pod restarts, GC pauses, connection pool usage).
+- **Logs** in the affected namespace around the alert start time, filtered for
+  ERROR/WARN and for the SQLSTATE / error code mentioned in the alert
+  description (e.g. `57014` for transaction timeouts).
+- **Traces** for the slowest requests touching the affected component, if a
+  tracing datasource exists for that service.
+- **Profiles** (CPU / memory / lock contention) when the alert points at
+  resource exhaustion or unusually long operations.
+
+Always pass the alert's `Grafana URL`, bearer token, namespace, and time window
+through verbatim.
+
+### 4. Collect Evidence via `sre-kubernetes`
+
+Use the `sre-kubernetes` skill to check the cluster identified
+`<Grafana Url>/api/datasources/proxy/uid/kubernetes/proxy` and the
+`<Grafana Credentials>`. At minimum, gather:
+
+- Pods in the affected namespace that are not `Running`/`Ready`, with restart
+  counts and last termination reasons.
+- Recent `Warning` events in the namespace.
+- Recent deployments / rollouts that started within the alert window — a recent
+  rollout is the single most common root cause and is easy to confirm.
+- Resource pressure on the nodes that host the affected workload (CPU, memory,
+  disk).
+
+### 5. Correlate and Decide
+
+Now connect the dots. Useful questions:
+
+- Did the metric break **at the same time** as a deploy, scale event, or config
+  change? Use `kubectl rollout history` and events from step 4.
+- Are the errors **localized** to one pod, one node, one client, or one
+  database? Localization narrows the cause dramatically.
+- Does the log line contain a stack trace, slow query, or SQL statement that
+  names the offending code path?
+- Is the metric anomaly **leading** (cause) or **lagging** (effect) the
+  business-level symptom?
+
+If the evidence does not yet point at a single cause, loop back to step 3 with a
+sharper query — don't speculate further without data.
+
+### 6. Report
+
+Produce a single, structured report. **Do not** narrate the whole investigation;
+the user wants the conclusion plus enough evidence to trust it.
+
+```markdown
+## Alert: <alertname>
+
+**Started:** <time> · **Cluster:** <cluster>/<env> · **Namespace:** <ns>
+
+### What Is Happening
+
+One sentence describing the user-visible / system-visible symptom.
+
+### Root Cause
+
+The single most likely cause, stated as a claim, not a question.
+
+### Evidence
+
+- <metric / log / trace / k8s finding that supports the claim, with a link or
+  query string the user can re-run>
+- <…>
+
+### Why This Caused the Alert
+
+One short paragraph connecting the cause to the alert expression.
+
+### Fix
+
+1. <Immediate mitigation — what to do in the next 5 minutes>
+2. <Durable fix — code, config, or process change>
+3. <Follow-up — monitoring, tests, or runbook updates>
+
+### Confidence
+
+high / medium / low, with the main remaining unknown if not high.
+```
+
+## Hard Rules
+
+- **Never** invent metric values, log lines, pod names, or timestamps. If a
+  query returned nothing, say so — silence is a finding.
+- **Never** suggest a destructive action (restart, rollback, scale to zero, drop
+  table, kill pod) without flagging it explicitly and asking the user to
+  confirm.
+- **Always** include the time window and exact query / `kubectl` command for
+  each piece of evidence, so the user can reproduce it.
+- **Always** prefer the runbook's recommended checks over your own
+  improvisations when a runbook exists — the team author knew the failure mode.
+- If two phases disagree (e.g. metrics say "fine" but logs say "broken"),
+  surface the contradiction instead of picking one and moving on.
+
+## Worked Example (Abbreviated)
+
+Alert: `PostgresTransactionTimeout` in namespace `grafana`, database
+`postgres_grafana`, cluster `de1/dev`, started 13:18.
+
+1. **Hypothesis:** a long-running job, a leaking service, or a tightened
+   timeout.
+2. **Grafana:**
+   - Query `pg_stat_database_xact_rollback{datname="postgres_grafana"}` rate
+     over the last 1h.
+   - Query the **Postgres Performance** dashboard for max transaction duration
+     by state.
+   - Search VictoriaLogs `service.namespace:="grafana"} AND *:"SQLSTATE 57014"`
+     for the offending statement.
+3. **Kubernetes:** check
+   `kubectl -n grafana get events --sort-by=.lastTimestamp` and
+   `kubectl -n grafana rollout history deploy` for recent changes.
+4. **Decision:** if the rollback rate spiked exactly when a deploy rolled out
+   AND the SQLSTATE log line names a specific query, the root cause is that
+   deploy's code change. Otherwise, look at the longest transaction owner.
+5. **Report** with the structure above.

--- a/.config/claude/skills/sre-analyze-alert/references/grafana-alert-source.md
+++ b/.config/claude/skills/sre-analyze-alert/references/grafana-alert-source.md
@@ -1,0 +1,95 @@
+# Grafana Alert Source
+
+Use this reference when only the Grafana alert source is provided in the format
+`<grafana-url>/alerting/grafana/<alert-id>/view` (e.g.,
+`https://grafana.example.com/alerting/grafana/alert-kubenodeeviction/view`).
+
+## Grafana Instance
+
+Use the `GRAFANA_INSTANCES` environment variable to get the correct Grafana url
+and the credentials for the Grafana API access. If you are not sure which
+instance to use, show a list of available instances and ask the user to select
+one.
+
+## Alert Details
+
+Use the Grafana API to get the details of the alert. The relevant API endpoint
+is:
+
+```bash
+curl -sS -H "Authorization: $TOKEN" \
+  -X GET "$GRAFANA/api/ruler/grafana/api/v1/rule/$ALERTID"
+```
+
+The response looks like this:
+
+```json
+{
+  "labels": {},
+  "annotations": {},
+  "grafana_alert": {
+    "title": "<alert-name>",
+    "data": [],
+    "uid": "<alert-id>",
+    "namespace_uid": "<folder-uid>",
+    "rule_group": "<rule-group>"
+  }
+}
+```
+
+Use the details from the response to get the actual alerts:
+
+```bash
+curl -sS -H "Authorization: $TOKEN" \
+  -X GET "$GRAFANA/api/prometheus/grafana/api/v1/rules?rule_group=<rule-group>&rule_group[]=<rule-group>&rule_name=<alert-name>&rule_name[]=<alert-name>&folder_uid=<folder-uid>"
+```
+
+The response contains a list of all the alerts in the
+`data.groups[].rules[].alerts` field:
+
+```json
+{
+  "status": "success",
+  "data": {
+    "groups": [
+      {
+        "name": "<rule-group>",
+        "folderUid": "<folder-uid>",
+        "rules": [
+          {
+            "alerts": [
+              {
+                "labels": {
+                  "__name__": "",
+                  "alertname": "",
+                  "severity": "",
+                  "<more-labels>": "..."
+                },
+                "annotations": {
+                  "__dashboardUid__": "",
+                  "__panelId__": "",
+                  "description": "",
+                  "runbook_url": "",
+                  "summary": ""
+                  "<more-annotations>": "..."
+                },
+                "state": "",
+                "activeAt": "",
+                "value": ""
+              }
+            ],
+            "uid": "<alert-id>",
+            "folderUid": "<folder-uid>"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Show the user a list of all active alerts
+(`jq '[.data.groups[].rules[].alerts[]]'`) and let them select the one they want
+to investigate. Use the `labels` field to provide more context about each alert
+in the list. Once the user selects an alert, use its details to start the
+investigation in the `sre-analyze-alert` skill.

--- a/.config/claude/skills/sre-grafana/SKILL.md
+++ b/.config/claude/skills/sre-grafana/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: sre-grafana
+description: |
+  Query a Grafana instance for metrics, logs, traces, and profiles to
+  investigate an alert or answer related questions. Triggers when the user asks
+  to "check Grafana" or "query metrics/logs/traces/profiles", references a
+  Prometheus, VictoriaMetrics, VictoriaLogs, VictoriaTraces, Tempo, or
+  Pyroscope datasource exposed through Grafana, or when the `sre-analyze-alert`
+  skill needs supporting evidence. Selects the appropriate datasource, runs
+  the query against Grafana's HTTP API, and summarizes the result.
+---
+
+# SRE: Grafana
+
+Investigate alerts and answer observability questions by pulling metrics, logs,
+traces, and profiles **through the Grafana HTTP API** — never by hitting the
+underlying datasources directly.
+
+## Inputs
+
+Resolve every required input before running a query. If anything is missing, ask
+the user — do not guess.
+
+All requests authenticate with `Authorization: Bearer <token>`. **Never** log,
+echo, or write the bearer token to disk.
+
+### Always Required
+
+| Input        | Example                                                                                 |
+| ------------ | --------------------------------------------------------------------------------------- |
+| Time range   | RFC3339 / Unix-ms `start` and `end` / relative `start` and `end` (e.g. `now-1h`, `now`) |
+| Query target | Metric name, LogQL expression, trace ID, etc.                                           |
+
+### How To Reach Grafana — One of the Following
+
+**Option A — by instance name:** the user supplies a name and the skill resolves
+the base URL and token from the `$GRAFANA_INSTANCES` environment variable. Each
+entry maps a name to its base URL and a shell command that prints the bearer
+token; run that command to obtain the token at query time.
+
+| Input                 | Example           |
+| --------------------- | ----------------- |
+| Grafana instance name | `example-grafana` |
+
+**Option B — by direct credentials:** the user supplies the base URL and a
+bearer token explicitly.
+
+| Input            | Example                       |
+| ---------------- | ----------------------------- |
+| Grafana base URL | `https://grafana.example.com` |
+| Bearer token     | `Bearer glsa_…`               |
+
+### Optional
+
+| Input          | Example                                      |
+| -------------- | -------------------------------------------- |
+| Datasource UID | Resolved via `/api/datasources` if not given |
+
+## Step 0 — Resolve the Datasource UID
+
+Every query in the later steps is addressed to a **datasource UID**, not to a
+signal type — so before running the first query against a Grafana instance you
+have not yet seen this session, list its datasources and pick the UID that
+matches the signal you need (metrics, logs, traces, or profiles).
+
+If the user supplied a UID up front, skip this step and use it directly.
+Otherwise, enumerate the available datasources:
+
+```bash
+curl -sS -H "Authorization: $TOKEN" "$GRAFANA/api/datasources" \
+  | jq '[.[] | {uid, name, type}]'
+```
+
+Map the signal you need to a UID using the `type` field:
+
+| Signal     | Datasource `type` values                           |
+| ---------- | -------------------------------------------------- |
+| Metrics    | `prometheus`, `victoriametrics-metrics-datasource` |
+| Logs       | `victoriametrics-logs-datasource`                  |
+| Traces     | `jaeger`, `tempo`                                  |
+| Profiles   | `grafana-pyroscope-datasource`                     |
+| Kubernetes | `ricoberger-kubernetes-datasource`                 |
+| Cloudflare | `ricoberger-cloudflare-datasource`                 |
+
+If more than one datasource matches a signal, prefer the one whose `name`
+clearly references the environment or cluster in question; if still ambiguous,
+ask the user which one to use rather than guessing.
+
+Cache the resulting signal-to-UID mapping for the rest of the session so
+follow-up queries can reuse it without re-listing the datasources.
+
+## Step 1 — Pick a Time Window
+
+Normalize whatever the user provided into a form Grafana accepts for `from` and
+`to` — relative expressions (`now`, `now-1h`), Unix-ms strings, or RFC3339 — and
+**always pass the window explicitly**; never rely on Grafana defaults.
+
+Handle the common inputs as follows:
+
+| User-supplied form                                             | How to pass it                                                                                                                                                                                 |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unix-ms pair (e.g. `Start: 1780471618000, End: 1780471631000`) | Pass straight through as `from` / `to` strings — no conversion needed.                                                                                                                         |
+| Human-readable timestamp (e.g. `3. Jun 2026 at 9:11`)          | Convert to RFC3339 with an explicit timezone (e.g. `2026-06-03T09:11:00+02:00`). If the user did not state a timezone, ask before assuming one.                                                |
+| "Current" / no timestamp given                                 | Default to `from: now-1h`, `to: now`.                                                                                                                                                          |
+| Alert payload with a `startsAt` / `Started:`                   | Anchor on `startsAt` / `Started:`: query from `startsAt - 30m` to `now` (or to `endsAt` if the alert has already cleared). If `startsAt` is older than 1h, widen the start to cover the onset. |
+
+If only one bound is provided, fill the other from context: a lone start
+defaults the end to `now`; a lone end defaults the start to `end - 1h`.
+
+## Step 2 — Run the Query
+
+Every query goes through one of two HTTP patterns:
+
+- `POST /api/ds/query` — Prometheus / VictoriaMetrics, VictoriaLogs, Tempo /
+  VictoriaTraces, Pyroscope and Cloudflare. The body is a Grafana panel-query
+  payload; multiple `queries[]` entries in a single POST fan out cheaply. Always
+  set `Content-Type: application/json`.
+- `GET /api/datasources/proxy/uid/<uid>/...` — Kubernetes proxy.
+
+Pass the `from` / `to` window resolved in Step 1 explicitly on every request; do
+not rely on Grafana defaults.
+
+The exact request body, query syntax, gotchas, and worked examples differ per
+datasource. After resolving the UID in Step 0, open the matching reference and
+follow it:
+
+| Signal     | Datasource `type`                                  | Reference                                                  |
+| ---------- | -------------------------------------------------- | ---------------------------------------------------------- |
+| Metrics    | `prometheus`, `victoriametrics-metrics-datasource` | [`references/prometheus.md`](references/prometheus.md)     |
+| Logs       | `victoriametrics-logs-datasource`                  | [`references/victorialogs.md`](references/victorialogs.md) |
+| Traces     | `jaeger`, `tempo`                                  | [`references/tempo.md`](references/tempo.md)               |
+| Profiles   | `grafana-pyroscope-datasource`                     | [`references/pyroscope.md`](references/pyroscope.md)       |
+| Kubernetes | `ricoberger-kubernetes-datasource`                 | [`references/kubernetes.md`](references/kubernetes.md)     |
+| Cloudflare | `ricoberger-cloudflare-datasource`                 | [`references/cloudflare.md`](references/cloudflare.md)     |
+
+### Discovering Existing Dashboards
+
+Existing dashboards capture the queries the team already trusts — reuse them
+instead of inventing your own. There are two situations where you should look
+for one:
+
+**1. When investigating an alert.** Check the alert's annotations in this order:
+
+- `__dashboardUid__` — fetch the dashboard directly by UID.
+- `runbook_url` — when it points at a Grafana dashboard (path matches `/d/<uid>`
+  or `/d/<uid>/<slug>`), extract the UID from the path and any `var-*` query
+  parameters as label values. Example:
+  `https://grafana.example.com/d/runbook-kubedeploymentrolloutstuck?var-namespace=istio-system&var-deployment=istiod`
+  -> UID `runbook-kubedeploymentrolloutstuck`, variables
+  `namespace=istio-system` and `deployment=istiod`. Pass the `var-*` values
+  through as template variables (`scopedVars`) when running the dashboard's
+  queries so they resolve to the labels the alert is actually about.
+
+**2. When asked to analyze the health of a service.** Search for dashboards that
+already describe that service, in this order:
+
+1. Tag match — `query=&tag=<service>` (most precise; teams tag service
+   dashboards by service name).
+2. Folder match — list folders via `/api/folders`, and if one matches the
+   service name, list its dashboards with `query=&folderUIDs=<uid>`.
+3. Free-text search — `query=<service>` as a fallback.
+
+If exactly one dashboard is found, **ask the user** whether to use it before
+running its queries. If multiple are found, list them (title + folder + UID) and
+ask which one to use. Never auto-pick — the wrong dashboard sends the
+investigation in the wrong direction.
+
+```bash
+# Fetch a dashboard by UID
+curl -sS -H "Authorization: $TOKEN" "$GRAFANA/api/dashboards/uid/$UID"
+
+# Search by tag (preferred for service lookups)
+curl -sS -G -H "Authorization: $TOKEN" "$GRAFANA/api/search" \
+  --data-urlencode "tag=$SERVICE"
+
+# List folders, then list dashboards inside a folder
+curl -sS -H "Authorization: $TOKEN" "$GRAFANA/api/folders"
+curl -sS -G -H "Authorization: $TOKEN" "$GRAFANA/api/search" \
+  --data-urlencode "folderUIDs=$FOLDER_UID"
+
+# Free-text search for dashboards
+curl -sS -G -H "Authorization: $TOKEN" "$GRAFANA/api/search" \
+  --data-urlencode "query=$TEXT"
+```
+
+## Step 3 — Summarize, Don’t Dump
+
+Raw API output is verbose. Always reduce it before reporting:
+
+- For metrics: report the **peak**, **current**, and **baseline** values, plus
+  the labels of the top contributors.
+- For logs: pull out the unique error templates (dedupe by message structure,
+  not by full string), with one example timestamp each.
+- For traces: report the slowest span, its service, and its error status.
+- For profiles: report the top 3–5 stack frames by self-time.
+
+When in doubt, include the exact query you ran so the user can re-execute it.
+
+## Common Pitfalls
+
+- **Wrong UID**: the Grafana UI shows datasource _names_; the API uses _UIDs_.
+  Resolve UIDs first (or use the well-known UIDs from Step 0).
+- **Wrong syntax dialect**: LogsQL is **not** LogQL / Loki.
+  `{namespace="x"} |= "error"` returns nothing because the parser silently
+  fails. Use `k8s.namespace.name:="x" AND error | sort by (_time) desc` instead.
+- **Wrong unit for time**: `/api/ds/query` accepts Grafana relative times
+  (`now-1h`) or Unix-ms. Mixing seconds and milliseconds silently returns empty
+  results.
+- **Empty result != healthy**: an empty LogsQL response can mean "no logs match"
+  OR "wrong field selector". Always sanity-check with a broader query (drop the
+  field filter, widen the time window).
+- **Cardinality explosions**: avoid `by (pod)` aggregations across the whole
+  cluster — scope to a namespace first.
+- **Token redaction**: never echo the bearer token, never write it to a temp
+  file, never include it in the report back to the user.
+
+## Hand-Off
+
+When invoked by `sre-analyze-alert`, return only the distilled findings (peak
+values, top offenders, representative log lines, slowest trace) plus the exact
+queries used. Do not draft conclusions about root cause — that synthesis belongs
+to the calling skill.

--- a/.config/claude/skills/sre-grafana/references/cloudflare.md
+++ b/.config/claude/skills/sre-grafana/references/cloudflare.md
@@ -1,0 +1,155 @@
+# Cloudflare
+
+Use this reference for datasource `type` `ricoberger-cloudflare-datasource`.
+Queries go through `/api/ds/query`.
+
+## Request
+
+```bash
+curl -sS -H "Authorization: $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$GRAFANA/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": { "uid": "'"$DATASOURCEUID"'", "type": "grafana-pyroscope-datasource" },
+      "queryType": "metrics",A
+      "zone": "'"$ZONE"'",
+      "limit": '"${LIMIT:-1000}"',
+      "name": "'"$METRICNAME"'",
+      "aggregation": "count",
+      "filterType": "code",
+      "filter": "",
+      "dimensions": [],
+      "orderBy": []
+    }],
+    "from": "'"$FROM"'",
+    "to": "'"$TO"'"
+  }'
+
+```
+
+If the `$ZONE` is not specified, get a list of available Cloudflare zones, using
+the `zones` query type and ask the user to select one. Always use the zone id in
+queries and not the zone name:
+
+```bash
+curl -sS -H "Authorization: $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$GRAFANA/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": { "uid": "'"$DATASOURCEUID"'", "type": "ricoberger-cloudflare-datasource" },
+      "queryType": "zones"
+    }],
+    "from": "'"$FROM"'",
+    "to": "'"$TO"'"
+  }'
+```
+
+## Cloudflare Query Patterns
+
+### Metrics
+
+The following metrics are available:
+
+- `httpRequests`: Returns the sampled logs of HTTP requests from Cloudflare.
+- `httpRequests_visits`: Returns the visit metrics for HTTP requests from
+  Cloudflare. Always prefer this over `httpRequests` for request count metrics,
+  as it provides more accurate counts.
+
+### Filter
+
+To filter the returned logs or metrics use the `filter` field. The filter syntax
+must be a valid GraphQL filter expression.
+
+The following fields can be used within the `filter`: `botManagementDecision`,
+`cacheStatus`, `clientASNDescription`, `clientAsn`, `clientCountryName`,
+`clientDeviceType`, `clientIP`, `clientRefererHost`, `clientRequestHTTPHost`,
+`clientRequestHTTPMethodName`, `clientRequestHTTPProtocol`, `clientRequestPath`,
+`clientRequestQuery`, `clientRequestReferer`, `clientRequestScheme`,
+`clientSSLProtocol`, `coloCode`, `edgeDnsResponseTimeMs`,
+`edgeResponseContentTypeName`, `edgeResponseStatus`, `edgeTimeToFirstByteMs`,
+`originASN`, `originASNDescription`, `originIP`, `originResponseDurationMs`,
+`originResponseStatus`, `rayName`, `requestSource`, `securityAction`,
+`upperTierColoName`, `userAgent`, `userAgentBrowser`, `userAgentOS`,
+`verifiedBotCategory`, `wafAttackScore`, `wafAttackScoreClass`,
+`wafRceAttackScore`, `wafSqliAttackScore`, `wafXssAttackScore`.
+
+Always include the `requestSource: "eyeball"` filter when analyzing traffic
+patterns, as this ensures that only traffic from real users is included in the
+analysis. Exclude this filter when analyzing bot traffic or when analyzing
+traffic patterns that may be affected by bots or when requested by the user.
+
+#### Examples
+
+- Only show logs / metrics where the `edgeResponseContentTypeName` is `json`,
+  `xml`, `grpc`, or `grpcweb` and where the data is comming from an `eyeball`
+  request:
+
+```graphql
+{
+  OR: [
+    {
+      edgeResponseContentTypeName: "json"
+    },
+    {
+      edgeResponseContentTypeName: "xml"
+    },
+    {
+      edgeResponseContentTypeName: "grpc"
+    },
+    {
+      edgeResponseContentTypeName: "grpcweb"
+    }
+  ]
+},
+{
+  requestSource: "eyeball"
+}
+```
+
+- Only show logs / metrics where the `edgeResponseStatus` is `200` and the
+  `edgeResponseContentTypeName` is `html`:
+
+```graphql
+{
+  requestSource: "eyeball"
+},
+{
+  AND: [
+    {
+      edgeResponseStatus: 200,
+      edgeResponseContentTypeName: "html"
+    }
+  ]
+}
+```
+
+### Dimensions
+
+The `dimensions` field is a list of fields to group the returned logs or metrics
+by. The syntax is a list of field names, e.g.
+`["datetimeFiveMinutes", "clientCountryName"]`.
+
+The following fields can be use within the `dimensions` field:
+`botManagementDecision`, `cacheStatus`, `clientASNDescription`, `clientAsn`,
+`clientCountryName`, `clientDeviceType`, `clientIP`, `clientRefererHost`,
+`clientRequestHTTPHost`, `clientRequestHTTPMethodName`,
+`clientRequestHTTPProtocol`, `clientRequestPath`, `clientRequestQuery`,
+`clientRequestReferer`, `clientRequestScheme`, `clientSSLProtocol`, `coloCode`,
+`date`, `datetime`, `datetimeFifteenMinutes`, `datetimeFiveMinutes`,
+`datetimeHour`, `datetimeMinute`, `edgeDnsResponseTimeMs`,
+`edgeResponseContentTypeName`, `edgeResponseStatus`, `edgeTimeToFirstByteMs`,
+`originASN`, `originASNDescription`, `originIP`, `originResponseDurationMs`,
+`originResponseStatus`, `requestSource`, `securityAction`, `upperTierColoName`,
+`userAgent`, `userAgentBrowser`, `userAgentOS`, `verifiedBotCategory`,
+`wafAttackScore`, `wafAttackScoreClass`, `wafRceAttackScore`,
+`wafSqliAttackScore`, `wafXssAttackScore`.
+
+If the metrics should be analyzed over time always include a datetime dimension,
+e.g. `datetimeFiveMinutes` or `datetimeHour`.
+
+## References
+
+- [GitHub Repository](https://github.com/ricoberger/grafana-cloudflare-plugin)
+- [Cloudflare GraphQL API](https://developers.cloudflare.com/analytics/graphql-api/)

--- a/.config/claude/skills/sre-grafana/references/kubernetes.md
+++ b/.config/claude/skills/sre-grafana/references/kubernetes.md
@@ -1,0 +1,22 @@
+# Kubernetes
+
+Use this reference for datasource `type` `ricoberger-kubernetes-datasource`.
+Queries go through `/api/datasources/proxy/uid/.../proxy/...`.
+
+```bash
+curl -sS -H "Authorization: $TOKEN" \
+  "$GRAFANA/api/datasources/proxy/uid/$DATASOURCEUID/proxy/$KUBERNETESAPIPATH"
+```
+
+### Kubenretes Query Patterns
+
+The `$KUBERNETESAPIPATH` is the path component of the Kubernetes API URL. Some
+useful paths are:
+
+- `/api/v1/namespaces/<ns>/pods` — list pods in a namespace.
+- `/api/v1/namespaces/<ns>/pods/<pod>` — single pod.
+- `/api/v1/namespaces/<ns>/events?fieldSelector=type=Warning` — recent warnings.
+- `/apis/apps/v1/namespaces/<ns>/deployments/<deployment>`
+- `/apis/apps/v1/namespaces/<ns>/statefulsets/<statefulset>`
+
+For deeper triage, hand off to the `sre-kubernetes` skill.

--- a/.config/claude/skills/sre-grafana/references/prometheus.md
+++ b/.config/claude/skills/sre-grafana/references/prometheus.md
@@ -1,0 +1,226 @@
+# Prometheus / VictoriaMetrics
+
+Use this reference for datasource `type` values `prometheus` and
+`victoriametrics-metrics-datasource`. Queries go through `POST /api/ds/query`.
+
+## Request
+
+```bash
+curl -sS -H "Authorization: $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$GRAFANA/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": { "uid": "'"$DATASOURCEUID"'", "type": "prometheus" },
+      "expr": "'"$PROMQL"'",
+      "instant": false,
+      "range": true,
+      "intervalMs": 15000,
+      "maxDataPoints": '"${MAXDATAPOINTS:-1000}"'
+    }],
+    "from": "'"$FROM"'",
+    "to": "'"$TO"'"
+  }'
+```
+
+## PromQL Query Patterns
+
+PromQL is a functional query language for time series data. Every query returns
+either an **instant vector** (one value per label set at a point in time), a
+**range vector** (a sliding window of samples), or a **scalar**.
+
+**Golden rule:** `rate()` and `increase()` always require a range vector. The
+range must be at least 4x the scrape interval to avoid gaps. For a 60s scrape
+interval, use `[5m]` minimum.
+
+### Rate and Counter Queries
+
+**Rate (per-second average over a window):**
+
+```promql
+rate(http_requests_total[5m])
+```
+
+**Rate with label aggregation — "sum then rate" is wrong, always rate then
+sum:**
+
+```promql
+# CORRECT: rate first, then aggregate
+sum(rate(http_requests_total{job="api"}[5m])) by (status_code)
+
+# WRONG: sum first destroys the counter monotonicity
+sum(http_requests_total) by (status_code)   -- do NOT then rate() this
+```
+
+**Increase (total count over a window, not per-second):**
+
+```promql
+increase(http_requests_total[1h])
+```
+
+**irate vs rate:**
+
+- `rate()` - smooth average over the full window. Use for dashboards and alerts.
+- `irate()` - instantaneous rate from the last two samples. Use only when you
+  need to capture spikes that `rate()` would average away. Never use for
+  alerting.
+
+### Filtering With Label Matchers
+
+```promql
+# Exact match
+http_requests_total{job="api", status_code="200"}
+
+# Regex match (anchored automatically)
+http_requests_total{status_code=~"5.."}
+
+# Negative regex
+http_requests_total{status_code!~"2.."}
+
+# Multiple values with regex OR
+http_requests_total{env=~"staging|production"}
+```
+
+### Aggregation Operators
+
+Always aggregate after `rate()`:
+
+```promql
+# Sum across all instances, keep service label
+sum(rate(http_requests_total[5m])) by (service)
+
+# Average CPU per node, drop all other labels
+avg(node_cpu_seconds_total{mode="idle"}) by (instance)
+
+# 95th percentile request duration
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_seconds_bucket[5m])) by (le, service)
+)
+
+# Top 5 services by request rate
+topk(5, sum(rate(http_requests_total[5m])) by (service))
+
+# Count of distinct label values
+count(count(up) by (job)) by ()
+```
+
+**`without` vs `by`:**
+
+```promql
+# Keep only the labels listed
+sum(rate(http_requests_total[5m])) by (service, status_code)
+
+# Drop only the labels listed, keep everything else
+sum(rate(http_requests_total[5m])) without (instance, pod)
+```
+
+### Histogram Quantiles
+
+Native histograms (Prometheus 2.40+) and classic histograms use different
+syntax.
+
+**Classic histogram (bucket metrics with `_bucket` suffix):**
+
+```promql
+histogram_quantile(0.99,
+  sum(rate(http_request_duration_seconds_bucket{job="api"}[5m])) by (le)
+)
+```
+
+**Multi-service comparison:**
+
+```promql
+histogram_quantile(0.95,
+  sum(rate(http_request_duration_seconds_bucket[5m])) by (le, service)
+)
+```
+
+**Common mistake:** forgetting `by (le)` in the inner aggregation drops the
+bucket boundaries, making `histogram_quantile` produce wrong results or NaN.
+
+**Native histograms (simpler syntax):**
+
+```promql
+histogram_quantile(0.95, sum(rate(http_request_duration_seconds[5m])))
+```
+
+### Ratio and Error Rate
+
+```promql
+# Error ratio (errors / total)
+sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+/
+sum(rate(http_requests_total[5m]))
+
+# Success rate as percentage
+(1 -
+  sum(rate(http_requests_total{status_code=~"5.."}[5m]))
+  /
+  sum(rate(http_requests_total[5m]))
+) * 100
+
+# Avoid division by zero with or vector(0)
+sum(rate(errors_total[5m]))
+/
+(sum(rate(requests_total[5m])) > 0)
+```
+
+### Absence and Staleness
+
+```promql
+# Alert when a metric disappears (e.g. a job stops reporting)
+absent(up{job="api"})
+
+# Alert when a metric value hasn't changed (potential stale exporter)
+changes(up{job="api"}[5m]) == 0
+
+# Check if a metric has been present in the last window
+count_over_time(up{job="api"}[5m]) > 0
+```
+
+### Time Functions and Offsets
+
+```promql
+# Compare current value to 1 hour ago
+rate(http_requests_total[5m])
+-
+rate(http_requests_total[5m] offset 1h)
+
+# Day-over-day comparison
+rate(http_requests_total[5m])
+/
+rate(http_requests_total[5m] offset 1d)
+
+# Predict value in 2 hours based on current trend (linear regression)
+predict_linear(node_filesystem_avail_bytes[1h], 2 * 3600)
+```
+
+### Common Patterns
+
+**Service availability (for use in alert rules):**
+
+```promql
+avg_over_time(up{job="api"}[5m]) < 0.9
+```
+
+**Saturation (resource near-full):**
+
+```promql
+# Disk filling up (predict full in < 4h based on 1h trend)
+predict_linear(node_filesystem_avail_bytes{mountpoint="/"}[1h], 4 * 3600) < 0
+```
+
+**Throughput spike:**
+
+```promql
+# Current rate > 3x the 1-hour average
+rate(http_requests_total[5m])
+>
+3 * avg_over_time(rate(http_requests_total[5m])[1h:5m])
+```
+
+### References
+
+- [Prometheus querying basics](https://prometheus.io/docs/prometheus/latest/querying/basics/)
+- [Prometheus best practices](https://prometheus.io/docs/practices/naming/)
+- [VictoriaMetrics MetricsQL](https://docs.victoriametrics.com/victoriametrics/metricsql/)

--- a/.config/claude/skills/sre-grafana/references/pyroscope.md
+++ b/.config/claude/skills/sre-grafana/references/pyroscope.md
@@ -1,0 +1,128 @@
+# Pyroscope
+
+Use this reference for datasource `type` `grafana-pyroscope-datasource`. Queries
+go through `/api/ds/query`.
+
+## Request
+
+```bash
+curl -sS -H "Authorization: $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$GRAFANA/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": { "uid": "'"$DATASOURCEUID"'", "type": "grafana-pyroscope-datasource" },
+      "labelSelector": "'"$LABELSELECTOR"'",
+      "groupBy": [],
+      "spanSelector": [],
+      "includeExemplars": false,
+      "queryType": "both",
+      "profileTypeId": "'"$PROFILETYPEID"'",
+      "intervalMs": 2000,
+      "maxDataPoints": '"'"${MAXDATAPOINTS:-1000}"'"
+    }],
+    "from": "'"$FROM"'",
+    "to": "'"$TO"'"
+  }'
+```
+
+## Pyroscope Query Patterns
+
+### Label Selector
+
+- `{ service_name="frontend" }`: Match profiles from the `frontend` service.
+- `{ service_name="frontend", env="production" }`: Match profiles from the
+  `frontend` service in the `production` environment.
+- `{ service_name=~"frontend|backend" }`: Match profiles from either `frontend`
+  or `backend` services.
+
+### Useful Labels
+
+- `service_name`: The name of the service that generated the profile.
+- `arch`: The architecture of the system (e.g., `amd64`, `arm64`).
+- `span_name`: The name of the span associated with the profile (if applicable).
+- `pod`: The Kubernetes pod name (if running in Kubernetes).
+
+### Group Profiles
+
+Use the `groupBy` field to group profiles by specific labels, e.g.
+`service_name` or `arch`. This allows you to compare profiles across different
+services or architectures.
+
+### Profile Type IDs
+
+Profile type IDs follow the format
+`<name>:<sample_type>:<sample_unit>:<period_type>:<period_unit>`. Well-known
+profile types include:
+
+- `process_cpu:cpu:nanoseconds:cpu:nanoseconds`
+- `memory:alloc_in_new_tlab_objects:count:space:bytes`
+- `memory:alloc_in_new_tlab_bytes:bytes:space:bytes`
+- `memory:alloc_outside_tlab_objects:count:space:bytes`
+- `memory:alloc_outside_tlab_bytes:bytes:space:bytes`
+- `mutex:contentions:count:mutex:count`
+- `mutex:delay:nanoseconds:mutex:count`
+- `block:contentions:count:block:count`
+- `block:delay:nanoseconds:block:count`
+
+#### CPU
+
+- **`process_cpu:cpu:nanoseconds:cpu:nanoseconds`** — On-CPU time per stack
+  frame, in nanoseconds. Shows where the process actually burns CPU cycles. The
+  workhorse profile for finding hot code paths — high samples mean a function is
+  consuming CPU. Sourced from Linux `perf`-style CPU sampling (Go/Rust/eBPF) or
+  JFR's `jdk.ExecutionSample` event (JVM).
+
+#### Memory (JVM-specific — TLAB = Thread-Local Allocation Buffer)
+
+The JVM gives each thread a private slice of the Eden generation called a TLAB
+so threads can bump-the-pointer allocate without locking. When an allocation
+fits, it's "in new TLAB"; when it's too big, it goes directly to the shared heap
+as "outside TLAB."
+
+- **`memory:alloc_in_new_tlab_objects:count:space:bytes`** — Number of objects
+  allocated that triggered a new TLAB. Counter of small/normal allocations
+  sampled by the JVM.
+- **`memory:alloc_in_new_tlab_bytes:bytes:space:bytes`** — Bytes allocated in
+  new TLABs. Tells you _how much_ memory those normal allocations consumed —
+  useful for finding allocation-heavy code paths.
+- **`memory:alloc_outside_tlab_objects:count:space:bytes`** — Number of "large"
+  object allocations that bypassed TLABs. These are slower and usually worth
+  investigating.
+- **`memory:alloc_outside_tlab_bytes:bytes:space:bytes`** — Bytes allocated
+  outside TLABs. Spikes here often indicate large arrays, big buffers, or
+  oversized objects causing GC pressure.
+
+Sources: JFR events `jdk.ObjectAllocationInNewTLAB` and
+`jdk.ObjectAllocationOutsideTLAB`.
+
+#### Mutex contention
+
+- **`mutex:contentions:count:mutex:count`** — Number of times a thread had to
+  wait to acquire a mutex/lock. High counts = frequent contention on a lock.
+- **`mutex:delay:nanoseconds:mutex:count`** — Total time (ns) threads spent
+  blocked waiting on mutexes. A few contentions with huge delay is a long-held
+  lock; many contentions with small delay is a hot but short-held lock.
+
+#### Blocking operations (Go: channels, condvars, select, etc.)
+
+- **`block:contentions:count:block:count`** — Number of times a goroutine/thread
+  blocked on a non-mutex synchronization primitive (channel send/recv,
+  `sync.Cond`, `select` etc. in Go).
+- **`block:delay:nanoseconds:block:count`** — Total wait time (ns) spent on
+  those blocking operations. Useful for finding goroutines stuck waiting on
+  channels or I/O coordination.
+
+#### Quick reading guide
+
+| You want to find…                 | Look at                                                        |
+| --------------------------------- | -------------------------------------------------------------- |
+| CPU hot paths                     | `process_cpu:cpu:nanoseconds:...`                              |
+| Allocation hotspots / GC pressure | `memory:alloc_in_new_tlab_bytes:...`                           |
+| Large/unusual allocations         | `memory:alloc_outside_tlab_bytes:...`                          |
+| Lock contention                   | `mutex:delay:nanoseconds:...` (then check `mutex:contentions`) |
+| Goroutine wait on channels/I/O    | `block:delay:nanoseconds:...`                                  |
+
+Rule of thumb: `*:delay:nanoseconds` answers "where is time _lost_?", while
+`*:contentions:count` answers "where does it happen _often_?". Use them
+together.

--- a/.config/claude/skills/sre-grafana/references/tempo.md
+++ b/.config/claude/skills/sre-grafana/references/tempo.md
@@ -1,0 +1,91 @@
+# Tempo / VictoriaTraces
+
+Use this reference for datasource `type` values `tempo`. Queries go through
+`POST /api/ds/query`.
+
+## Request
+
+```bash
+curl -sS -H "Authorization: $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$GRAFANA/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": { "uid": "victoriatraces", "type": "tempo" },
+      "queryType": "traceql",
+      "limit": '"${LIMIT:-20}"',
+      "metricsQueryType": "range",
+      "query": "'"$TRACEQL"'"
+    }],
+    "from": "'"$FROM"'",
+    "to": "'"$TO"'"
+  }'
+```
+
+## TraceQL Query Patterns
+
+TraceQL is a functional query language, which is designed for querying and
+analyzing distributed tracing data. TraceQL allows you to filter, aggregate, and
+visualize traces based on various attributes and conditions.
+
+### Filter Syntax
+
+- `{ }`: Match all traces.
+- `{resource.service.name = "frontend" && name = "POST /api/orders"}`: Match
+  traces where the `resource.service.name` attribute equals `frontend` and the
+  span name equals `POST /api/orders`.
+- `{ resource.deployment.environment = "production" } && { resource.deployment.environment = "staging" }`:
+  Match traces that go through `production` and `staging` instances.
+- `{ span.foo != "bar" }`: Match traces where no span has the attribute `foo`
+  equal to `bar`.
+- `{ span.http.request.header.Accept =~ "application.*" }`: Match traces where
+  at least one span has an `http.request.header.Accept` that matches the regex
+  `application.*`.
+- `{ span.http.request.header.Accept !~ "application.*" }`: Match traces where
+  no span has an `http.request.header.Accept` that matches the regex
+  `application.*`.
+- `{ resource.service.name="frontend" } >> { status = error }`: Match traces
+  that include the `frontend` service, where either that service or a downstream
+  service includes a span where an error is set.
+- `{ } !< { resource.service.name = "productcatalogservice" }`: Match all leaf
+  spans that end in the `productcatalogservice`.
+- `{ resource.service.name = "productcatalogservice" } ~ { resource.service.name="frontend" }`:
+  Match if `productcatalogservice` and `frontend` are siblings.
+- `{ trace:duration > 5s }`: Match traces that took longer than 5 seconds.
+
+### Pipes
+
+- `{ resource.service.name = "frontend" } | rate() by (status)`: Match traces
+  that include the `frontend` service, and count the number of spans by their
+  status (e.g. `error`, `ok`).
+- `{ name = "GET /:endpoint" } | quantile_over_time(duration, .99) by (span.http.target)`:
+  Match traces that include a span with the name `GET /:endpoint`, and calculate
+  the 99th percentile of the duration of those spans, grouped by their
+  `span.http.target` attribute.
+
+### Find a Single Trace by ID
+
+To find a single trace by its unique identifier, you can use the following
+TraceQL query: `{trace_id="fa619c7dbdf256c067fd3ce215905bc6"}`. This is useful
+if you have the trace ID from a log entry or an error report and want to
+retrieve the full trace for analysis.
+
+### Useful Fields
+
+- `trace_id`: The unique identifier for a trace.
+- `name`: The operation or span name.
+- `duration`: The duration of a trace.
+- `status`: The status of a span, useful when looking for errors
+  (`{ status="error" }`).
+- `resource.service.name`: The name of the service associated with a span.
+
+### References
+
+- [Construct a TraceQL query](https://grafana.com/docs/tempo/latest/traceql/construct-traceql-queries/)
+- [TraceQL metrics](https://grafana.com/docs/tempo/latest/metrics-from-traces/metrics-queries/)
+
+## What To Look For
+
+- The longest span in the trace.
+- Spans with an error status.
+- The call-graph branch that diverged from a healthy baseline trace.

--- a/.config/claude/skills/sre-grafana/references/victorialogs.md
+++ b/.config/claude/skills/sre-grafana/references/victorialogs.md
@@ -1,0 +1,136 @@
+# VictoriaLogs
+
+Use this reference for datasource `type` `victoriametrics-logs-datasource`.
+Queries go through `POST /api/ds/query`.
+
+**LogsQL is not LogQL and not Loki.** Do not emit Loki-style stream selectors
+(`{namespace="foo"} |= "error"`) or pipe filters (`|=`, `!=`, `|~`) — the parser
+silently fails and returns nothing. Full reference:
+[https://docs.victoriametrics.com/victorialogs/logsql/](https://docs.victoriametrics.com/victorialogs/logsql/).
+
+## Request
+
+```bash
+curl -sS -H "Authorization: $TOKEN" -H "Content-Type: application/json" \
+  -X POST "$GRAFANA/api/ds/query" \
+  -d '{
+    "queries": [{
+      "refId": "A",
+      "datasource": { "uid": "'"$DATASOURCEUID"'", "type": "victoriametrics-logs-datasource" },
+      "expr": "'"$LOGSQL"'",
+      "queryType": "instant",
+      "maxLines": '"${MAXLINES:-1000}"'
+    }],
+    "from": "'"$FROM"'",
+    "to": "'"$TO"'"
+  }'
+```
+
+## LogsQL Query Patterns
+
+LogsQL is a simple yet powerful query language for VictoriaLogs. LogsQL provides
+the following features: Full-text search in any log field (defaults to `_msg` ).
+Ability to combine filters into arbitrary complex logical filters. Ability to
+calculate various stats over the selected log entries.
+
+### Filter Syntax
+
+Combine with `AND` / `OR` / `NOT`:
+
+- `word`: matches that word anywhere in the log line (default field `_msg`).
+- `"exact phrase"`: phrase match anywhere in the log line (default field
+  `_msg`).
+- `field:word`: word match on a specific field.
+- `field:="exact value"`: exact field match (most common for labels).
+- `field:"phrase"`: phrase match on a field.
+- `field:~"regex"`: regex on a field.
+- `severity_text:in("error","fatal","critical")`: set membership.
+- `field:range(4.2, Inf)`: numeric range match on a field.
+- `field:*`: field exists.
+- `field:""`: field does not exist.
+- `*:"word"`: word match across all fields.
+
+### Combining Filters
+
+Filters can be combined with logical operators `AND`, `OR`, and `NOT` to create
+complex queries. The `NOT` operation has the highest priority, `AND` has the
+middle priority and `OR` has the lowest priority. The priority order can be
+changed with parentheses, e.g. `NOT (field:word1 OR field:word2)`.
+
+### Pipes
+
+Applied after filters, left to right:
+
+- `| sort by (_time) desc` — newest first. Almost always include this.
+- `| limit 100` — cap result count.
+- `| stats by (severity_text) count(*) as n` — aggregate.
+- `| fields _time, _msg, k8s.pod.name` — project specific fields.
+
+### Useful Labels
+
+- `service.namespace`: The namespace of the service. Almost always this is the
+  Kubernetes namespace.
+- `service.name`: The name of the service. This is often the `app`, `k8s-app` or
+  `app.kubernetes.io/name` label.
+- `severity_text:` The severity level of the log entry, e.g. "error", "warning",
+  "info".
+- `k8s.container.name`: The name of the container that emitted the log entry.
+- `k8s.namespace.name`: The Kubernetes namespace of the pod that emitted the log
+  entry.
+- `k8s.node.name`: The name of the Kubernetes node on which the pod is running.
+- `k8s.pod.name`: The name of the Kubernetes pod that emitted the log entry.
+- `k8s.pod.uid`: The unique identifier of the Kubernetes pod that emitted the
+  log entry.
+
+### Severity Levels
+
+The `severity_text` label can have one of the following values for the different
+severity levels:
+
+- `critical`: "critical", "Critical", "CRITICAL", "fatal", "Fatal", "FATAL", "F"
+- `error`: "error", "Error", "ERROR", "err", "Err", "ERR", "E"
+- `warning`: "warning", "Warning", "WARNING", "warn", "Warn", "WARN", "W"
+- `info`: "info", "Info", "INFO", "information", "Information", "INFORMATION",
+  "informational", "Informational", "INFORMATIONAL", "notice", "Notice",
+  "NOTICE", "I"
+- `debug`: "debug", "Debug", "DEBUG"
+- `trace`: "trace", "Trace", "TRACE", "verbose", "Verbose", "VERBOSE"
+
+### Working Examples
+
+Errors for one service in one namespace, newest first:
+
+```
+service.namespace:="prod" AND service.name:="checkout"
+  AND severity_text:in("error","fatal")
+| sort by (_time) desc
+| limit 200
+```
+
+Errors from one specific pod:
+
+```
+k8s.namespace.name:="prod" AND k8s.pod.name:="checkout-7d8f-abcde"
+  AND (error OR panic OR fatal)
+| sort by (_time) desc
+| limit 200
+```
+
+Error count per minute over the window:
+
+```
+service.name:="checkout" AND severity_text:="error"
+| stats by (_time:1m) count(*) as errors
+```
+
+### Wrong Syntax (Loki Syntax — NEVER EMIT)
+
+- `{service_name="checkout"} |= "error"` ❌ Loki stream + pipe filter
+- `{namespace="prod", pod=~"checkout-.*"} != "ok"` ❌ Loki regex selector
+- `rate({app="checkout"}[5m])` ❌ Loki metric query
+
+### References
+
+- [VictoriaLogs LogsQL](https://docs.victoriametrics.com/victorialogs/logsql/)
+- [LogsQL examples](https://docs.victoriametrics.com/victorialogs/logsql-examples/)
+- [How to convert Loki queries to VictoriaLogs queries](https://docs.victoriametrics.com/victorialogs/logql-to-logsql/)

--- a/.config/claude/skills/sre-kubernetes/SKILL.md
+++ b/.config/claude/skills/sre-kubernetes/SKILL.md
@@ -1,0 +1,217 @@
+---
+name: sre-kubernetes
+description: |
+  Inspect a Kubernetes cluster — reachable via either an API server URL and
+  bearer token, or a context name from `~/.kube/config` — for failing pods,
+  warning events, recent rollouts, resource pressure, and other state relevant
+  to an SRE alert or question. Triggers when the user asks about pod /
+  deployment / node health, references a cluster URL + token, names a
+  kubeconfig context, or when `sre-analyze-alert` needs cluster-side evidence.
+  Read-only by default; destructive actions require explicit confirmation.
+---
+
+# SRE: Kubernetes
+
+Investigate the state of a Kubernetes cluster via the API server. The goal is to
+surface what is broken, what changed, and what looks unhealthy — never to mutate
+cluster state without explicit user approval.
+
+## Inputs
+
+The skill accepts **one of two** input modes. Ask the user which they want to
+use if it is not clear, and require the corresponding fields before issuing API
+calls:
+
+### Mode A — API Server URL + Bearer Token
+
+| Input          | Example                                        |
+| -------------- | ---------------------------------------------- |
+| API server URL | `https://kubernetes.example.com`               |
+| Bearer token   | `eyJhbGciOi…` (raw token, no `Bearer ` prefix) |
+
+### Mode B — Kubeconfig Context
+
+| Input        | Example                                     |
+| ------------ | ------------------------------------------- |
+| Context name | `kube-de1` (must exist in `~/.kube/config`) |
+
+Verify the context exists before issuing API calls:
+
+```bash
+kubectl config get-contexts -o name | grep -Fx "$CONTEXT"
+```
+
+If the lookup returns nothing, ask the user to correct the context name or
+switch to Mode A — do not silently fall back to the current context.
+
+## Choosing the Access Method
+
+Pick the path that matches the input mode the user provided:
+
+1. **`kubectl` with an inline server + token** (Mode A). No kubeconfig changes
+   needed:
+
+   ```bash
+   kubectl --server="$API" --token="$TOKEN" \
+     -n "$NS" get pods
+   ```
+
+2. **`kubectl` with a kubeconfig context** (Mode B). Always pass `--context`
+   explicitly — never rely on the current context:
+
+   ```bash
+   kubectl --context="$CONTEXT" \
+     -n "$NS" get pods
+   ```
+
+3. **Raw `curl` against the API server** (fallback for Mode A when `kubectl` is
+   not installed):
+
+   ```bash
+   curl -sS -H "Authorization: Bearer $TOKEN" \
+     "$API/api/v1/namespaces/$NS/pods" | jq '.items[] | {name: .metadata.name, phase: .status.phase}'
+   ```
+
+All paths require **read-only** verbs (`get`, `list`, `describe`, `logs`, `top`)
+unless the user explicitly approves a write.
+
+> The command examples in the rest of this skill use the Mode A form
+> (`--server` + `--token`). When operating in Mode B, replace those flags with
+> `--context="$CONTEXT"`.
+
+## Standard Triage Checklist
+
+Run these in order. Stop when you have enough to answer the question — there is
+no need to gather everything every time.
+
+### 1. Pods That Are Not Happy
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" get pods \
+  --field-selector=status.phase!=Running \
+  -o wide
+```
+
+Then for the most suspicious pod:
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" describe pod "$POD"
+```
+
+What to extract: `Status`, `Reason`, container `State` / `Last State` / `Reason`
+/ `ExitCode`, `Events` block at the bottom.
+
+### 2. Pods That _are_ Running but Unhealthy
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" get pods \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.containerStatuses[*].restartCount}{"\n"}{end}' \
+  | sort -k2 -n -r | head
+```
+
+High restart counts within the alert window almost always mean a
+CrashLoopBackOff or a failing liveness probe.
+
+### 3. Recent Events
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" get events \
+  --sort-by=.lastTimestamp \
+  --field-selector type=Warning | tail -50
+```
+
+Look for `FailedScheduling`, `BackOff`, `OOMKilled`, `Unhealthy`, `FailedMount`,
+`NodeNotReady`, image pull errors.
+
+### 4. Recent Rollouts / Config Changes
+
+A surprising number of alerts trace back to a deploy that landed minutes
+earlier:
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" get deploy,statefulset,daemonset \
+  -o jsonpath='{range .items[*]}{.kind}{"/"}{.metadata.name}{"\t"}{.metadata.generation}{"\t"}{.status.observedGeneration}{"\n"}{end}'
+
+kubectl --server="$API" --token="$TOKEN" -n "$NS" rollout history deploy/$DEPLOY
+```
+
+Cross-reference the rollout time with the alert `Started` timestamp.
+
+### 5. Logs From the Offending Container
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" logs "$POD" \
+  -c "$CONTAINER" --tail=200
+```
+
+If the container has restarted, fetch the previous log too:
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" logs "$POD" \
+  -c "$CONTAINER" --previous --tail=200
+```
+
+For larger log volumes, prefer the `sre-grafana` skill (Loki) — direct
+`kubectl logs` is bounded to a single container instance.
+
+### 6. Resource Pressure
+
+```bash
+kubectl --server="$API" --token="$TOKEN" -n "$NS" top pod
+kubectl --server="$API" --token="$TOKEN" top node
+```
+
+If `metrics-server` is unavailable these will fail — note that and fall back to
+`cAdvisor`-derived metrics via Grafana (`container_memory_working_set_bytes`,
+`container_cpu_usage_seconds_total`).
+
+### 7. Workload-Specific Checks
+
+Pick the ones relevant to the alert:
+
+- **CrashLoopBackOff**: previous-container logs (step 5) + describe for the exit
+  reason.
+- **Pending pods**: `kubectl describe pod` to see scheduler messages
+  (insufficient cpu/memory, taints, PVC pending).
+- **Image pull errors**: check `imagePullSecrets` and registry reachability.
+- **StatefulSet / PVC issues**: `kubectl get pvc,pv -n $NS` and check the
+  `Bound`/`Pending` state.
+- **Networking**: `kubectl get endpoints` for the service — a "no endpoints"
+  state usually means readiness probes are failing.
+
+## Reporting
+
+Hand back a compact summary, not raw command output. Include:
+
+1. **Unhealthy objects** (pod name → phase / reason / restart count).
+2. **Top warning events** in the namespace (deduplicated, with first/last
+   timestamps).
+3. **Recent rollouts** that overlap the alert window, with the new image tag or
+   revision.
+4. **Resource pressure** observations.
+5. The exact commands used, so the user can re-run them.
+
+Always include timestamps in the report — "5 pods restarted" without a window is
+useless.
+
+## Hard Rules
+
+- **No write verbs without explicit confirmation.** That includes `apply`,
+  `delete`, `patch`, `edit`, `scale`, `rollout undo`, `cordon`, `drain`, `exec`,
+  and `port-forward`. Always ask before running them, and show the user the
+  exact command first.
+- **Never** leak the bearer token (no echoing, no writing to disk, no including
+  it in URLs you pass back).
+- **Do not** `kubectl exec` into a pod just to poke around — prefer logs and
+  events. If exec is genuinely required, name the exact command and ask.
+- **Do not** assume the cluster identity from a hostname. If two labels point at
+  different clusters (`cluster=de1` vs the user's URL says `de2`), surface the
+  mismatch.
+- If a command returns no rows, say so explicitly. Empty results are evidence,
+  not failure.
+
+## Hand-Off
+
+When invoked by `sre-analyze-alert`, return only the distilled cluster findings
+(unhealthy pods, warning events, recent rollouts, resource pressure) plus the
+exact commands used. Leave root-cause synthesis to the caller.


### PR DESCRIPTION
This commit adds three new skills, related to SRE tasks.

**SRE Analyze Alert:**

This skill helps analyze alerts from Grafana. It provides detailed
insights on what happened, the potential root cause, evidence for the
alert and recommended fixes.

The skill requires an alert in markdown format as input from
https://github.com/ricoberger/Alertmanager or the source url of the
alert from Grafana, e.g.
`https://grafana.example/alerting/grafana/alert-fluxcdreconciliationfailure/view`.
If the source url is provided the skill detects the Grafana instance
from the `GRAFANA_INSTANCES` environment variable:

```json
{
  "my-grafana": {
    "url": "https://grafana.example.com",
    "auth": {
      "tokenCommand": "cat $HOME/.kube/cache/kubectl-grafana/grafana.example.com_kubernetes.json | jq -r '.status.token'"
    }
  }
}
```

The skill then uses the `sre-grafana` and `sre-kubernetes` skills to
analyze the alert and provide insights.

**SRE Grafana:**

This skill helps to query data from Grafana. It supports the following
signals and data sources:

- Metrics: Prometheus and VictoriaMetrics
- Logs: VictoriaLogs
- Traces: Tempo and VictoriaTraces
- Profiles: Pyroscope
- Kubernetes: [Grafana Kubernetes
  Plugin](https://github.com/ricoberger/grafana-grafana-plugin)
- Cloudflare: [Grafana Cloudflare
  Plugin](https://github.com/ricoberger/grafana-cloudflare-plugin)

The Grafana instance which should be used can be detected by providing
the Grafana instance url and authentication token or by providing the
name from the `GRAFANA_INSTANCES` environment variable.

**SRE Kubernetes:**

This skill helps to query data from a Kubernetes cluster to debug
issues. The cluster can be specified by providing the Kubernetes API
server url and authentication token or by providing the context from the
Kubeconfig file at `~/.kube/config`.
